### PR TITLE
Model

### DIFF
--- a/emart2/src/main/java/com/example/emart2/entity/BaseEntity.java
+++ b/emart2/src/main/java/com/example/emart2/entity/BaseEntity.java
@@ -1,6 +1,7 @@
 package com.example.emart2.entity;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -22,7 +23,8 @@ public abstract class BaseEntity {
   @Column(nullable = false)
   private LocalDateTime updatedAt;
 
-
-
+  @Column(nullable = false)
+  @Setter
+  protected boolean isActive;
 
 }

--- a/emart2/src/main/java/com/example/emart2/entity/Category.java
+++ b/emart2/src/main/java/com/example/emart2/entity/Category.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 import javax.persistence.*;
 
 @Getter
-@Entity @Table(name = "Category")
+@Entity @Table(name = "category")
 public class Category extends BaseEntity {
 
   @Id
@@ -22,25 +22,22 @@ public class Category extends BaseEntity {
   @Setter
   private String description;
 
-  @Column(nullable = false)
-  @Setter
-  private boolean isActive;
 
-  @Column(length=50, nullable = false)
   @Setter
-  private int order;
+  @Column(nullable = false)
+  private int colOrder;
 
   @Builder
   public Category(String name, String description){
     this.name = name;
     this.description = description;
-    this.order = 0;
+    this.colOrder = 0;
     this.isActive = true;
   }
 
   public Category(){
     this.isActive = true;
-    this.order = 0;
+    this.colOrder = 0;
   }
 
 }


### PR DESCRIPTION
1. isActive 칼럼을 baseEntity로 옮김
2. order라는 칼럼명이 예약어와 겹치는 문제로 인해 colOrder로 명칭 변경